### PR TITLE
package as npm module; bump version

### DIFF
--- a/History.md
+++ b/History.md
@@ -15,3 +15,6 @@
 
 ### 0.0.6
    * Check image even if `$watch` doesn't call with `null` the first time.
+
+### 0.0.7
+   * Expose as npm package too.

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,15 @@ In JS, to let it register its AngularJS module:
 
 In HTML:
 
-    <script src="components/hugojosefson-image-url-for-angular/index.js"></script>
+    <script src="bower_components/hugojosefson-image-url-for-angular/index.js"></script>
+
+### With [npm](https://www.npmjs.com/)
+
+    $ npm install hugojosefson/image-url-for-angular
+
+In HTML:
+
+    <script src="node_modules/image-url-for-angular/index.js"></script>
 
 ### Old-school
 
@@ -64,7 +72,7 @@ the attribute `image-url-integrate-with-form-validity="false"` on the `<input />
 
 For most cases you can check for a valid image by checking the width and/or height models instead, if you expect images
 to be > 0 pixels.
-       
+
 
 ## License
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "hugojosefson-image-url-for-angular",
-  "version": "0.0.6.snapshot",
+  "version": "0.0.7.snapshot",
   "main": "index.js",
   "ignore": [
     "example/**"

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "image-url-for-angular",
   "repo": "hugojosefson/image-url-for-angular",
   "description": "AngularJS directive for validating and figuring out width/height from an image url.",
-  "version": "0.0.6.snapshot",
+  "version": "0.0.7.snapshot",
   "keywords": ["angularjs", "angular", "image", "valid", "dimensions", "width", "height", "url"],
   "dependencies": {},
   "development": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "image-url-for-angular",
+  "version": "0.0.7",
+  "description": "AngularJS directive for validating and figuring out width/height from an image url.",
+  "main": "index.js",
+  "directories": {
+    "example": "example"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hugojosefson/image-url-for-angular"
+  },
+  "author": "Hugo Josefson",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/hugojosefson/image-url-for-angular/issues"
+  },
+  "homepage": "https://github.com/hugojosefson/image-url-for-angular"
+}


### PR DESCRIPTION
This adds a `package.json` file to allow for installation via npm.

It might be nice to also add (in a separate PR) a [UMD wrapper](http://dontkry.com/posts/code/browserify-and-the-universal-module-definition.html) - let me know if you'd like me to take a shot at that. I'm using Browserify so in the meantime, I just plan to use a transform to expose the `imageUrlModule` global in CommonJS style.
